### PR TITLE
fixed project deletion on windows

### DIFF
--- a/src/son_editor/apis/gitapi.py
+++ b/src/son_editor/apis/gitapi.py
@@ -27,6 +27,7 @@ clone_model = namespace.model('Clone information', {
 })
 
 delete_model = namespace.model('Delete information', {
+    'project_id': fields.Integer(description='Project ID of the project to get diff information'),
     'repo_name': fields.String(description='Remote repository that gets deleted'),
     'owner': fields.String(
         description='Owner/organization name of the repository\'s owner, otherwise user as owner is taken',
@@ -75,7 +76,7 @@ class GitDelete(Resource):
     def delete(self, ws_id):
         """ Deletes a remote repository"""
         json_data = get_json(request)
-        result = delete(ws_id, shlex.quote(json_data['repo_name']))
+        result = delete(ws_id, int(json_data['project_id']), shlex.quote(json_data['repo_name']))
         return prepare_response(result, 200)
 
 

--- a/src/son_editor/impl/gitimpl.py
+++ b/src/son_editor/impl/gitimpl.py
@@ -292,7 +292,7 @@ def delete(ws_id: int, project_id: int, remote_repo_name: str, organization_name
     project = get_project(ws_id, project_id, sql_session)
     url_decode = parse.urlparse(project.repo_url)
     if _repo_name_from_url(url_decode) == remote_repo_name:
-        result = requests.delete(build_github_delete(owner, remote_repo_name), headers=create_oauth_header())
+        result = _do_delete(owner, remote_repo_name)
         if result.status_code == 204:
             project.repo_url = None
             sql_session.commit()
@@ -301,6 +301,10 @@ def delete(ws_id: int, project_id: int, remote_repo_name: str, organization_name
             sql_session.rollback()
             return create_info_dict(result.text, exitcode=1)
     raise InvalidArgument("The given repo name does not correspond to the remote repository name")
+
+
+def _do_delete(owner, remote_repo_name):
+    return requests.delete(build_github_delete(owner, remote_repo_name), headers=create_oauth_header())
 
 
 def diff(ws_id: int, pj_id: int):
@@ -384,6 +388,7 @@ def list(ws_id: int):
 def _repo_name_from_url(url_decode: str):
     github_project_name = os.path.split(url_decode.path)[-1]
     return github_project_name.replace('.git', '')
+
 
 def clone(ws_id: int, url: str, name: str = None):
     """

--- a/src/son_editor/tests/git_api_test.py
+++ b/src/son_editor/tests/git_api_test.py
@@ -48,7 +48,7 @@ class GitAPITest(unittest.TestCase):
     def clean_github(self):
         """ Deletes the created test project(s) on github """
         # Clean github repository
-        arg = {'repo_name': REMOTE_REPO_NAME}
+        arg = {'project_id': self.pjid, 'repo_name': REMOTE_REPO_NAME}
         self.app.delete("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/delete",
                         headers={'Content-Type': 'application/json'},
                         data=json.dumps(arg))
@@ -86,7 +86,7 @@ class GitAPITest(unittest.TestCase):
         response = self.call_github_post('clone', arg)
         self.assertResponseValid(response)
 
-        arg = {'repo_name': REMOTE_REPO_NAME}
+        arg = {'project_id': self.pjid, 'repo_name': REMOTE_REPO_NAME}
         response = self.app.delete("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/delete",
                                    headers={'Content-Type': 'application/json'},
                                    data=json.dumps(arg))

--- a/src/son_editor/tests/git_api_test.py
+++ b/src/son_editor/tests/git_api_test.py
@@ -3,6 +3,8 @@ import unittest
 import logging
 import time
 
+from son_editor.impl import gitimpl
+from son_editor.models.project import Project
 from son_editor.tests.utils import *
 from son_editor.util.context import init_test_context
 from son_editor.util.requestutil import CONFIG
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 # Get the github_bot_user / github_access_token from the CONFIG,
 # otherwise take it from the environment variable (which should be set on travis)
 
+GITHUB_URL = "http://github.com"
 REMOTE_REPO_NAME = 'test_create'
 
 GITHUB_USER = os.environ["github_bot_user"] if not 'github_bot_user' in CONFIG else CONFIG['github_bot_user']
@@ -47,6 +50,11 @@ class GitAPITest(unittest.TestCase):
 
     def clean_github(self):
         """ Deletes the created test project(s) on github """
+        # set url on project to be able to delete
+        dbsession = db_session()
+        dbsession.query(Project).filter(Project.id == self.pjid) \
+            .first().repo_url = GITHUB_URL + "/" + GITHUB_USER + "/" + REMOTE_REPO_NAME
+        dbsession.commit()
         # Clean github repository
         arg = {'project_id': self.pjid, 'repo_name': REMOTE_REPO_NAME}
         self.app.delete("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/delete",
@@ -81,10 +89,13 @@ class GitAPITest(unittest.TestCase):
         response = self.app.get("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/list")
 
         # List functionality
+        arg = {'url': json.loads(response.data.decode())[0]['clone_url']}
         logger.info('arg: {}'.format(json.loads(response.data.decode())[0]['clone_url']))
-        pj_id = create_project(int(self.wsid), REMOTE_REPO_NAME, json.loads(response.data.decode())[0]['clone_url'])
+        response = self.call_github_post('clone', arg)
+        self.assertResponseValid(response)
+        json_data = json.loads(response.data.decode())
+        arg = {'project_id': json_data['id'], 'repo_name': REMOTE_REPO_NAME}
 
-        arg = {'project_id': pj_id, 'repo_name': REMOTE_REPO_NAME}
         response = self.app.delete("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/delete",
                                    headers={'Content-Type': 'application/json'},
                                    data=json.dumps(arg))

--- a/src/son_editor/tests/git_api_test.py
+++ b/src/son_editor/tests/git_api_test.py
@@ -32,7 +32,7 @@ class GitAPITest(unittest.TestCase):
         # Create a workspace and project
         self.wsid = str(create_workspace(self.user, 'WorkspaceA'))
         # Create sample project
-        self.pjid = str(create_project(self.wsid, 'ProjectA'))
+        self.pjid = str(create_project(int(self.wsid), 'ProjectA'))
         self.clean_github()
 
     def tearDown(self):
@@ -81,12 +81,10 @@ class GitAPITest(unittest.TestCase):
         response = self.app.get("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/list")
 
         # List functionality
-        arg = {'url': json.loads(response.data.decode())[0]['clone_url']}
         logger.info('arg: {}'.format(json.loads(response.data.decode())[0]['clone_url']))
-        response = self.call_github_post('clone', arg)
-        self.assertResponseValid(response)
+        pj_id = create_project(int(self.wsid), REMOTE_REPO_NAME, json.loads(response.data.decode())[0]['clone_url'])
 
-        arg = {'project_id': self.pjid, 'repo_name': REMOTE_REPO_NAME}
+        arg = {'project_id': pj_id, 'repo_name': REMOTE_REPO_NAME}
         response = self.app.delete("/" + constants.WORKSPACES + "/" + self.wsid + "/" + constants.GIT + "/delete",
                                    headers={'Content-Type': 'application/json'},
                                    data=json.dumps(arg))

--- a/src/son_editor/tests/utils.py
+++ b/src/son_editor/tests/utils.py
@@ -151,7 +151,7 @@ def delete_workspace(testcase, ws_id: int):
     return response.status_code == 200
 
 
-def create_project(ws_id: int, project_name: str, repo: str = None) -> str:
+def create_project(ws_id: int, project_name: str) -> str:
     """
     Creates a project
 
@@ -160,4 +160,4 @@ def create_project(ws_id: int, project_name: str, repo: str = None) -> str:
     :param project_name: Name of the workspace that gets created
     :return: ID of the created project
     """
-    return son_editor.impl.projectsimpl.create_project(ws_id, {'name': project_name, 'repo': repo})['id']
+    return son_editor.impl.projectsimpl.create_project(ws_id, {'name': project_name})['id']

--- a/src/son_editor/tests/utils.py
+++ b/src/son_editor/tests/utils.py
@@ -151,12 +151,13 @@ def delete_workspace(testcase, ws_id: int):
     return response.status_code == 200
 
 
-def create_project(ws_id: int, project_name: str) -> str:
+def create_project(ws_id: int, project_name: str, repo: str = None) -> str:
     """
     Creates a project
-    :param testcase: Testcase instance to call HTTP requests
+
+    :param repo: the repository url, None by default
     :param ws_id: The workspace where the project gets created
     :param project_name: Name of the workspace that gets created
     :return: ID of the created project
     """
-    return son_editor.impl.projectsimpl.create_project(ws_id, {'name': project_name})['id']
+    return son_editor.impl.projectsimpl.create_project(ws_id, {'name': project_name, 'repo': repo})['id']


### PR DESCRIPTION
require project id to delete remote to remove remote from project descriptor and check if remote_name is the one referenced by the project